### PR TITLE
chore(room)!: replace Comparator with Comparable

### DIFF
--- a/src/main/java/net/onelitefeather/coris/room/BaseRoom.java
+++ b/src/main/java/net/onelitefeather/coris/room/BaseRoom.java
@@ -99,11 +99,8 @@ public class BaseRoom implements Room {
         return this.shape;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public int compare(Key o1, Key o2) {
-        return o1.compareTo(o2);
+    public int compareTo(Room other) {
+        return this.identifier.compareTo(other.identifier());
     }
 }

--- a/src/main/java/net/onelitefeather/coris/room/Room.java
+++ b/src/main/java/net/onelitefeather/coris/room/Room.java
@@ -5,8 +5,6 @@ import net.onelitefeather.coris.component.Componentable;
 import net.onelitefeather.coris.shape.Shape;
 import org.jetbrains.annotations.ApiStatus;
 
-import java.util.Comparator;
-
 /**
  * The {@link Room} interface represents a room which describes a specific area.
  * If the area is a room in a world or building is up to the implementation.
@@ -24,7 +22,7 @@ import java.util.Comparator;
  * @since 0.1.0
  */
 @ApiStatus.Experimental
-public interface Room extends Componentable, Comparator<Key> {
+public interface Room extends Componentable, Comparable<Room> {
 
     /**
      * Returns the identifier of the room.

--- a/src/test/java/net/onelitefeather/coris/room/RoomTest.java
+++ b/src/test/java/net/onelitefeather/coris/room/RoomTest.java
@@ -16,4 +16,14 @@ class RoomTest {
         assertEquals(Key.key("test_room"), room.identifier());
         assertInstanceOf(CuboidShape.class, room.shape());
     }
+
+    @Test
+    void testRoomComparison() {
+        Room roomA = new TestRoom(Key.key("coris:room_a"));
+        Room roomB = new TestRoom(Key.key("coris:room_b"));
+
+        assertTrue(roomA.compareTo(roomB) < 0, "Room A should be less than Room B based on alphabetical key sorting");
+        assertTrue(roomB.compareTo(roomA) > 0, "Room B should be greater than Room A");
+        assertEquals(0, roomA.compareTo(roomA), "A room compared with itself should return 0");
+    }
 }


### PR DESCRIPTION
## Proposed changes

Currently, the Room object uses a Comparator with a Key argument from Adventure. This is somewhat misleading and may cause confusion. This pull request updates it to Comparable, which takes a Room type as its argument. This makes it clearer that it compares Room instances rather than keys.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)