### PR TITLE
chore(intersect)!: remove 2D / 3D intersection split

### DIFF
--- a/src/main/java/net/onelitefeather/coris/floor/CorisFloorRegistry.java
+++ b/src/main/java/net/onelitefeather/coris/floor/CorisFloorRegistry.java
@@ -104,7 +104,7 @@ public class CorisFloorRegistry<T extends Floor<Room>> implements FloorRegistry<
     @Override
     public Optional<T> getFloorAt(Point point) {
         return this.floors.values().stream()
-                .filter(floor -> Objects.requireNonNull(floor.shape()).intersect3D(point))
+                .filter(floor -> Objects.requireNonNull(floor.shape()).intersect(point))
                 .findFirst();
     }
 }

--- a/src/main/java/net/onelitefeather/coris/floor/FloorRegistry.java
+++ b/src/main/java/net/onelitefeather/coris/floor/FloorRegistry.java
@@ -83,7 +83,7 @@ public interface FloorRegistry<T extends Floor<Room>> {
     default Optional<Room> getRoomAt(Point point) {
         return getFloorAt(point).flatMap(floor ->
                 floor.getData().values().stream()
-                        .filter(room -> room.shape().intersect3D(point))
+                        .filter(room -> room.shape().intersect(point))
                         .findFirst()
         );
     }

--- a/src/main/java/net/onelitefeather/coris/shape/CuboidShape.java
+++ b/src/main/java/net/onelitefeather/coris/shape/CuboidShape.java
@@ -10,7 +10,7 @@ import org.jetbrains.annotations.ApiStatus;
  * @param start the starting point of the cuboid
  * @param end   the ending point of the cuboid
  * @author theEvilReaper
- * @version 1.4.0
+ * @version 1.5.0
  * @since 0.1.0
  */
 @ApiStatus.Experimental
@@ -78,19 +78,10 @@ public record CuboidShape(Vec start, Vec end) implements Shape {
      * {@inheritDoc}
      */
     @Override
-    public boolean intersect2D(Point position) {
-        return position.blockX() >= start.blockX() && position.blockX() <= end.blockX() &&
-                position.blockZ() >= start.blockZ() && position.blockZ() <= end.blockZ();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public boolean intersect3D(Point position) {
-        return position.blockX() >= start.blockX() && position.blockX() <= end.blockX() &&
-                position.blockY() >= start.blockY() && position.blockY() <= end.blockY() &&
-                position.blockZ() >= start.blockZ() && position.blockZ() <= end.blockZ();
+    public boolean intersect(Point position) {
+        return position.blockX() >= start.blockX() && position.blockX() <= end.blockX()
+                && position.blockY() >= start.blockY() && position.blockY() <= end.blockY()
+                && position.blockZ() >= start.blockZ() && position.blockZ() <= end.blockZ();
     }
 
     /**

--- a/src/main/java/net/onelitefeather/coris/shape/PointShape.java
+++ b/src/main/java/net/onelitefeather/coris/shape/PointShape.java
@@ -9,7 +9,7 @@ import net.minestom.server.coordinate.Vec;
  *
  * @param position the position of the point in the 3D space
  * @author theEvilReaper
- * @version 1.4.1
+ * @version 1.5.0
  * @since 0.1.0
  */
 public record PointShape(Vec position) implements Shape {
@@ -31,15 +31,7 @@ public record PointShape(Vec position) implements Shape {
      * {@inheritDoc}
      */
     @Override
-    public boolean intersect2D(Point position) {
-        return this.position.x() == position.x() && this.position.z() == position.z();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public boolean intersect3D(Point position) {
+    public boolean intersect(Point position) {
         return this.position.equals(position);
     }
 

--- a/src/main/java/net/onelitefeather/coris/util/Intersect.java
+++ b/src/main/java/net/onelitefeather/coris/util/Intersect.java
@@ -17,13 +17,6 @@ public interface Intersect<T extends Point> {
      * @param position the position to check
      * @return true if the point intersects with the shape, false otherwise
      */
-    boolean intersect2D(T position);
+    boolean intersect(T position);
 
-    /**
-     * Checks if the given point intersects with the shape in 3D.
-     *
-     * @param position the position to check
-     * @return true if the point intersects with the shape, false otherwise
-     */
-    boolean intersect3D(T position);
 }

--- a/src/main/java/net/onelitefeather/coris/util/Intersect.java
+++ b/src/main/java/net/onelitefeather/coris/util/Intersect.java
@@ -3,10 +3,16 @@ package net.onelitefeather.coris.util;
 import net.minestom.server.coordinate.Point;
 
 /**
- * The {@link Intersect} interface is used to determine if a point intersects with a shape.
+ * Provides intersection checks between a geometric shape and a point.
+ * <p>
+ * Implementations define how intersection is evaluated.
+ * This may represent 2D, 3D or hybrid spatial logic depending on the shape.
+ * <p>
+ * The caller MUST NOT assume any specific dimensional model.
  *
  * @param <T> the type of point
- * @version 1.1.0
+ * @author theEvilReaper
+ * @version 1.2.0
  * @since 0.1.0
  */
 public interface Intersect<T extends Point> {

--- a/src/test/java/net/onelitefeather/coris/shape/CuboidShapeTest.java
+++ b/src/test/java/net/onelitefeather/coris/shape/CuboidShapeTest.java
@@ -36,40 +36,26 @@ class CuboidShapeTest {
     }
 
     @Test
-    void testIntersect3D() {
+    void testIntersect() {
         CuboidShape shape = new CuboidShape(new Vec(0, 0, 0), new Vec(4, 4, 4));
 
-        // 1. Point fully inside
-        assertTrue(shape.intersect3D(new Vec(2, 2, 2)));
+        // inside
+        assertTrue(shape.intersect(new Vec(2, 2, 2)));
 
-        // 2. Point exactly on the boundary
-        assertTrue(shape.intersect3D(new Vec(0, 2, 4)));
+        // boundary
+        assertTrue(shape.intersect(new Vec(0, 2, 4)));
 
-        // 3. Point outside on X
-        assertFalse(shape.intersect3D(new Vec(-1, 2, 2)));
-        assertFalse(shape.intersect3D(new Vec(5, 2, 2)));
+        // outside X
+        assertFalse(shape.intersect(new Vec(-1, 2, 2)));
+        assertFalse(shape.intersect(new Vec(5, 2, 2)));
 
-        // 4. Point outside on Y
-        assertFalse(shape.intersect3D(new Vec(2, -1, 2)));
-        assertFalse(shape.intersect3D(new Vec(2, 5, 2)));
+        // outside Y
+        assertFalse(shape.intersect(new Vec(2, -1, 2)));
+        assertFalse(shape.intersect(new Vec(2, 5, 2)));
 
-        // 5. Point outside on Z
-        assertFalse(shape.intersect3D(new Vec(2, 2, -1)));
-        assertFalse(shape.intersect3D(new Vec(2, 2, 5)));
-    }
-
-    @Test
-    void testIntersect2D() {
-        // Y boundaries are ignored in 2D intersection
-        CuboidShape shape = new CuboidShape(new Vec(0, 0, 0), new Vec(4, 4, 4));
-
-        // 1. Point inside X/Z, but outside Y-bounds (should still intersect in 2D)
-        assertTrue(shape.intersect2D(new Vec(2, 10, 2)));
-        assertTrue(shape.intersect2D(new Vec(2, -5, 2)));
-
-        // 2. Point outside X/Z bounds
-        assertFalse(shape.intersect2D(new Vec(-1, 2, 2)));
-        assertFalse(shape.intersect2D(new Vec(2, 2, 5)));
+        // outside Z
+        assertFalse(shape.intersect(new Vec(2, 2, -1)));
+        assertFalse(shape.intersect(new Vec(2, 2, 5)));
     }
 
     @Test

--- a/src/test/java/net/onelitefeather/coris/shape/intersect/CuboidShapeIntersectTest.java
+++ b/src/test/java/net/onelitefeather/coris/shape/intersect/CuboidShapeIntersectTest.java
@@ -1,5 +1,6 @@
 package net.onelitefeather.coris.shape.intersect;
 
+import net.minestom.server.coordinate.Point;
 import net.minestom.server.coordinate.Vec;
 import net.onelitefeather.coris.shape.CuboidShape;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -12,9 +13,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class CuboidShapeIntersectTest {
 
-    private static final CuboidShape SHAPE = new CuboidShape(new Vec(0, 0, 0), new Vec(5, 5, 5));
+    private static final CuboidShape SHAPE =
+            new CuboidShape(new Vec(0, 0, 0), new Vec(5, 5, 5));
 
-    static Stream<Arguments> intersect3DProvider() {
+    static Stream<Arguments> intersectProvider() {
         return Stream.of(
                 Arguments.of(new Vec(2, 2, 2), true, "Inside shape"),
                 Arguments.of(new Vec(0, 0, 0), true, "On start border"),
@@ -25,27 +27,9 @@ class CuboidShapeIntersectTest {
         );
     }
 
-    static Stream<Arguments> intersect2DProvider() {
-        return Stream.of(
-                Arguments.of(new Vec(2, 99, 2), true, "Inside, Y ignored"),
-                Arguments.of(new Vec(0, 0, 0), true, "On start border"),
-                Arguments.of(new Vec(5, 0, 5), true, "On end border XZ"),
-                Arguments.of(new Vec(6, 2, 2), false, "Outside X"),
-                Arguments.of(new Vec(2, 2, 6), false, "Outside Z"),
-                Arguments.of(new Vec(2, 999, 2), true, "Large Y ignored"),
-                Arguments.of(new Vec(2, -999, 2), true, "Negative Y ignored")
-        );
-    }
-
     @ParameterizedTest(name = "{2}")
-    @MethodSource("intersect3DProvider")
-    void testIntersect3D(Vec position, boolean expected, String description) {
-        assertEquals(expected, SHAPE.intersect3D(position));
-    }
-
-    @ParameterizedTest(name = "{2}")
-    @MethodSource("intersect2DProvider")
-    void testIntersect2D(Vec position, boolean expected, String description) {
-        assertEquals(expected, SHAPE.intersect2D(position));
+    @MethodSource("intersectProvider")
+    void testIntersect(Point position, boolean expected, String description) {
+        assertEquals(expected, SHAPE.intersect(position));
     }
 }

--- a/src/test/java/net/onelitefeather/coris/shape/intersect/PointShapeIntersectTest.java
+++ b/src/test/java/net/onelitefeather/coris/shape/intersect/PointShapeIntersectTest.java
@@ -1,5 +1,6 @@
 package net.onelitefeather.coris.shape.intersect;
 
+import net.minestom.server.coordinate.Point;
 import net.minestom.server.coordinate.Vec;
 import net.onelitefeather.coris.shape.PointShape;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -12,9 +13,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class PointShapeIntersectTest {
 
-    private static final PointShape SHAPE = new PointShape(new Vec(2, 2, 2));
+    private static final PointShape SHAPE =
+            new PointShape(new Vec(2, 2, 2));
 
-    static Stream<Arguments> intersect3DProvider() {
+    static Stream<Arguments> intersectProvider() {
         return Stream.of(
                 Arguments.of(new Vec(2, 2, 2), true, "Exact match"),
                 Arguments.of(new Vec(3, 2, 2), false, "X mismatch"),
@@ -23,24 +25,9 @@ class PointShapeIntersectTest {
         );
     }
 
-    static Stream<Arguments> intersect2DProvider() {
-        return Stream.of(
-                Arguments.of(new Vec(2, 2, 2), true, "Exact match"),
-                Arguments.of(new Vec(3, 2, 2), false, "X mismatch"),
-                Arguments.of(new Vec(2, 3, 2), true, "Y ignored"),
-                Arguments.of(new Vec(2, 2, 3), false, "Z mismatch")
-        );
-    }
-
     @ParameterizedTest(name = "{2}")
-    @MethodSource("intersect3DProvider")
-    void testIntersect3D(Vec position, boolean expected, String description) {
-        assertEquals(expected, SHAPE.intersect3D(position));
-    }
-
-    @ParameterizedTest(name = "{2}")
-    @MethodSource("intersect2DProvider")
-    void testIntersect2D(Vec position, boolean expected, String description) {
-        assertEquals(expected, SHAPE.intersect2D(position));
+    @MethodSource("intersectProvider")
+    void testIntersect(Point position, boolean expected, String description) {
+        assertEquals(expected, SHAPE.intersect(position));
     }
 }


### PR DESCRIPTION
## Proposed changes

This change refactors the shape intersection API by removing the separation between 2D and 3D intersection methods.

Previously, shapes exposed both `intersect2D` and `intersect3D`, requiring callers to explicitly decide which dimensional context to use. This introduced ambiguity and pushed geometric concerns to the caller side.

## Design Decision

Shapes are now responsible for interpreting spatial behavior internally.  
This allows implementations to freely define whether they operate in 2D, 3D, or hybrid space without exposing this decision to API consumers.


## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)